### PR TITLE
Feature - Use ViewModel and UiState to update BartTestScreen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,7 @@ android {
 dependencies {
 
     def nav_version = "2.6.0"
+    def lifecycle_version = "2.6.1"
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation platform('org.jetbrains.kotlin:kotlin-bom:1.8.0')
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
@@ -65,6 +66,9 @@ dependencies {
 
     //Constraint Layout
     implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
+
+    // ViewModel utilities for Compose
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/app/src/main/java/com/example/dancognitionapp/bart/BalloonCanvas.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BalloonCanvas.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -15,13 +13,11 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.example.dancognitionapp.ui.LandscapePreview
 import com.example.dancognitionapp.ui.theme.DanCognitionAppTheme
 
 @Composable
-fun Balloon(
+fun BalloonCanvas(
     radius: Float,
     modifier: Modifier = Modifier
 ) {
@@ -98,6 +94,6 @@ fun Balloon(
 @Composable
 fun BalloonPreview() {
     DanCognitionAppTheme {
-        Balloon(radius = 200f, modifier = Modifier.fillMaxSize())
+        BalloonCanvas(radius = 200f, modifier = Modifier.fillMaxSize())
     }
 }

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartTestScreen.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartTestScreen.kt
@@ -72,7 +72,7 @@ fun BartTestScreen(modifier: Modifier = Modifier) {
                 }
             )
             BartTitleText(
-                dollarValue = uiState.balloonReward,
+                dollarValue = uiState.currentReward,
                 modifier = Modifier.constrainAs(dollarsLeft) {
                     centerHorizontallyTo(leftHeader)
                     top.linkTo(leftHeader.bottom)
@@ -120,7 +120,7 @@ fun BartTestScreen(modifier: Modifier = Modifier) {
                     width = Dimension.fillToConstraints
                 }
             ) {
-                viewModel.collectBalloonReward(uiState.balloonReward)
+                viewModel.collectBalloonReward(uiState.currentReward)
                 balloonRadius = initialBalloonRadius
             }
         }

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartTestScreen.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartTestScreen.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.dancognitionapp.R
 import com.example.dancognitionapp.ui.LandscapePreview
 import com.example.dancognitionapp.ui.theme.DanCognitionAppTheme
+import timber.log.Timber
 
 
 @Composable
@@ -107,7 +108,11 @@ fun BartTestScreen(modifier: Modifier = Modifier) {
                     viewModel.resetBalloonStatus()
                     /*TODO*/
                     // Replace lines below with "Balloon Popped" Dialog
-                    viewModel.inflateBalloon()
+                    viewModel.inflateBalloon(
+                        onBalloonPopped = { /*TODO - Callback to show dialog */ }
+                    ) {
+                        Timber.i("BART test completed via inflate (popping)")
+                    }
                     balloonRadius *= 1.08f
                 } else {
                     viewModel.inflateBalloon()
@@ -122,7 +127,9 @@ fun BartTestScreen(modifier: Modifier = Modifier) {
                     width = Dimension.fillToConstraints
                 }
             ) {
-                viewModel.collectBalloonReward()
+                viewModel.collectBalloonReward() {
+                    Timber.i("BART test completed via collect")
+                }
                 balloonRadius = initialBalloonRadius
             }
         }

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartTestScreen.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartTestScreen.kt
@@ -29,7 +29,7 @@ import com.example.dancognitionapp.ui.theme.DanCognitionAppTheme
 fun BartTestScreen(modifier: Modifier = Modifier) {
 
     val viewModel: BartViewModel = viewModel()
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState
 
     BoxWithConstraints(modifier = modifier
         .padding(12.dp)
@@ -105,6 +105,8 @@ fun BartTestScreen(modifier: Modifier = Modifier) {
                 if (uiState.balloonPopped) {
                     balloonRadius = initialBalloonRadius
                     viewModel.resetBalloonStatus()
+                    /*TODO*/
+                    // Replace lines below with "Balloon Popped" Dialog
                     viewModel.inflateBalloon()
                     balloonRadius *= 1.08f
                 } else {
@@ -120,7 +122,7 @@ fun BartTestScreen(modifier: Modifier = Modifier) {
                     width = Dimension.fillToConstraints
                 }
             ) {
-                viewModel.collectBalloonReward(uiState.currentReward)
+                viewModel.collectBalloonReward()
                 balloonRadius = initialBalloonRadius
             }
         }

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartTestScreen.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartTestScreen.kt
@@ -49,7 +49,7 @@ fun BartTestScreen(modifier: Modifier = Modifier) {
                 dollarsRight
             ) = createRefs()
 
-            Balloon(
+            BalloonCanvas(
                 modifier = modifier
                     .constrainAs(balloon) {
                         top.linkTo(parent.top)
@@ -126,9 +126,9 @@ fun BartTestScreen(modifier: Modifier = Modifier) {
  * */
 @Composable
 fun BartTitleText(
+    modifier: Modifier = Modifier,
     textResId: Int? = null,
-    dollarValue: Int? = null,
-    modifier: Modifier = Modifier
+    dollarValue: Int? = null
 ) {
     if (textResId != null) {
         Text(

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
@@ -16,28 +16,26 @@ class BartViewModel: ViewModel() {
      * */
     private val _uiState = mutableStateOf(
         BartUiState(
-            balloonList = balloonList,
-            currentBalloon = balloonList.first
+            balloonList = balloonList
         )
     )
     val uiState: State<BartUiState> = _uiState
     private val currentState: BartUiState
         get() = _uiState.value
     fun inflateBalloon() {
-        val isListEmpty: Boolean = balloonList.isEmpty()
-        if (isListEmpty) {
-            Timber.i("BART completed!")
-            return
-        }
+//        val isListEmpty: Boolean = balloonList.isEmpty()
+//        if (isListEmpty) {
+//            Timber.i("BART completed!")
+//            return
+//        }
         val canInflate =
             currentState.currentBalloon.maxInflations > currentState.currentInflationCount
 
         if (canInflate) {
-            val updatedState = currentState.copy(
+            _uiState.value = currentState.copy(
                 currentInflationCount = currentState.currentInflationCount.inc(),
                 currentReward = currentState.currentReward.inc()
             )
-            _uiState.value = updatedState
             Timber.i("Balloon Number ${currentState.currentBalloon.listPosition} was inflated!")
             Timber.d("\nInflations: ${currentState.currentInflationCount}" +
                     "\nmaxInflationCount: ${currentState.currentBalloon.maxInflations}" +
@@ -48,42 +46,39 @@ class BartViewModel: ViewModel() {
                     " Max Inflation: ${currentState.currentBalloon.maxInflations} " +
                     " == Number of User Clicks ${currentState.currentInflationCount + 1}"
             )
-            val updatedState = currentState.copy(
+            _uiState.value = currentState.copy(
                 currentInflationCount = 0,
                 currentReward = 1,
                 balloonPopped = true
             )
-            _uiState.value = updatedState
             toNextBalloon()
         }
     }
 
     fun resetBalloonStatus() {
-        val updatedState = currentState.copy(
+        _uiState.value = currentState.copy(
             balloonPopped = false
         )
-        _uiState.value = updatedState
         Timber.i("balloonPopped: ${_uiState.value.balloonPopped}")
     }
 
     fun collectBalloonReward() {
-        val isListEmpty: Boolean = balloonList.isEmpty()
-        if (isListEmpty) {
-            Timber.i("BART completed!")
-            return
-        }
-        val updatedState = currentState.copy(
+//        val isListEmpty: Boolean = balloonList.isEmpty()
+//        if (isListEmpty) {
+//            Timber.i("BART completed!")
+//            return
+//        }
+        _uiState.value = currentState.copy(
             totalEarnings = currentState.totalEarnings + currentState.currentReward,
             currentReward = 1,
             currentInflationCount = 0
         )
-        _uiState.value = updatedState
         Timber.i("Balloon Number ${currentState.currentBalloon.listPosition} collected!")
         toNextBalloon()
     }
 
     private fun toNextBalloon() {
-        val isLastBalloon: Boolean = currentState.balloonList.size == 1
+        val isLastBalloon: Boolean = currentState.balloonList.size == 0
 
         if (isLastBalloon) {
             /*TODO*/
@@ -91,10 +86,9 @@ class BartViewModel: ViewModel() {
             // disable buttons or go to completed screen?
             Timber.i("BART completed!")
         } else {
-            currentState.balloonList.removeFirst()
             _uiState.value = currentState.copy(
                 balloonList = balloonList,
-                currentBalloon = balloonList.first
+                currentBalloon = balloonList.pop()
             )
         }
     }

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
@@ -25,13 +25,13 @@ class BartViewModel: ViewModel() {
 
     fun inflateBalloon() {
         val canInflate =
-            _uiState.value.currentBalloon.maxInflations > _uiState.value.balloonInflations + 1
+            _uiState.value.currentBalloon.maxInflations > _uiState.value.currentInflationCount + 1
 
         if(canInflate) {
             _uiState.update {
                 it.copy(
-                    balloonInflations = it.balloonInflations.inc(),
-                    balloonReward = it.balloonReward.inc()
+                    currentInflationCount = it.currentInflationCount.inc(),
+                    currentReward = it.currentReward.inc()
                 )
             }
             Timber.i("Balloon Number ${_uiState.value.currentBalloon.listPosition} was inflated!")
@@ -39,12 +39,12 @@ class BartViewModel: ViewModel() {
             Timber.i(
                 "Balloon Number ${_uiState.value.currentBalloon.listPosition} popped!" +
                     " Max Inflation: ${_uiState.value.currentBalloon.maxInflations} " +
-                    " == Number of User Clicks ${_uiState.value.balloonInflations + 1}"
+                    " == Number of User Clicks ${_uiState.value.currentInflationCount + 1}"
             )
             _uiState.update {
                 it.copy(
-                    balloonInflations = 0,
-                    balloonReward = 1,
+                    currentInflationCount = 0,
+                    currentReward = 1,
                     balloonPopped = true
                 )
             }
@@ -64,8 +64,8 @@ class BartViewModel: ViewModel() {
         _uiState.update {
             it.copy(
                 totalEarnings = it.totalEarnings + reward,
-                balloonReward = 1,
-                balloonInflations = 0
+                currentReward = 1,
+                currentInflationCount = 0
             )
         }
         Timber.i("Balloon Number ${_uiState.value.currentBalloon.listPosition} collected!")

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
@@ -1,0 +1,95 @@
+package com.example.dancognitionapp.bart
+
+import androidx.lifecycle.ViewModel
+import com.example.dancognitionapp.bart.data.BalloonGenerator
+import com.example.dancognitionapp.bart.data.BartUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
+
+class BartViewModel: ViewModel() {
+
+    private var balloonList = BalloonGenerator().getBalloonLinkedList()
+
+    /**
+     * This first block sets up the ui state to be mutable and initializes the BalloonList
+     * */
+    private val _uiState = MutableStateFlow(
+        BartUiState(
+            balloonList = balloonList,
+            currentBalloon = balloonList.first
+        )
+    )
+    val uiState: StateFlow<BartUiState> = _uiState
+
+    fun inflateBalloon() {
+        val canInflate =
+            _uiState.value.currentBalloon.maxInflations > _uiState.value.balloonInflations + 1
+
+        if(canInflate) {
+            _uiState.update {
+                it.copy(
+                    balloonInflations = it.balloonInflations.inc(),
+                    balloonReward = it.balloonReward.inc()
+                )
+            }
+            Timber.i("Balloon Number ${_uiState.value.currentBalloon.listPosition} was inflated!")
+        } else {
+            Timber.i(
+                "Balloon Number ${_uiState.value.currentBalloon.listPosition} popped!" +
+                    " Max Inflation: ${_uiState.value.currentBalloon.maxInflations} " +
+                    " == Number of User Clicks ${_uiState.value.balloonInflations + 1}"
+            )
+            _uiState.update {
+                it.copy(
+                    balloonInflations = 0,
+                    balloonReward = 1,
+                    balloonPopped = true
+                )
+            }
+            toNextBalloon()
+        }
+    }
+
+    fun resetBalloonStatus() {
+        _uiState.update {
+            it.copy(
+                balloonPopped = false
+            )
+        }
+    }
+
+    fun collectBalloonReward(reward: Int) {
+        _uiState.update {
+            it.copy(
+                totalEarnings = it.totalEarnings + reward,
+                balloonReward = 1,
+                balloonInflations = 0
+            )
+        }
+        Timber.i("Balloon Number ${_uiState.value.currentBalloon.listPosition} collected!")
+        toNextBalloon()
+    }
+
+    private fun toNextBalloon() {
+        val isBalloonListEmpty: Boolean = _uiState.value.balloonList.size == 1
+
+        if (isBalloonListEmpty) {
+            /*TODO*/
+            // have something to show test is complete
+            Timber.i("BART completed!")
+        } else {
+            _uiState.value.balloonList.removeFirst()
+            _uiState.update {
+                it.copy(
+                    balloonList = balloonList,
+                    currentBalloon = balloonList.first
+                )
+            }
+
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
@@ -10,7 +10,7 @@ import timber.log.Timber
 
 class BartViewModel: ViewModel() {
 
-    private var balloonList = BalloonGenerator().getBalloonLinkedList()
+    private var balloonList = BalloonGenerator().balloons
 
     /**
      * This first block sets up the ui state to be mutable and initializes the BalloonList

--- a/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/BartViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import com.example.dancognitionapp.bart.data.BalloonGenerator
 import com.example.dancognitionapp.bart.data.BartUiState
 import timber.log.Timber
+import java.util.NoSuchElementException
 
 class BartViewModel: ViewModel() {
 
@@ -22,12 +23,10 @@ class BartViewModel: ViewModel() {
     val uiState: State<BartUiState> = _uiState
     private val currentState: BartUiState
         get() = _uiState.value
-    fun inflateBalloon() {
-//        val isListEmpty: Boolean = balloonList.isEmpty()
-//        if (isListEmpty) {
-//            Timber.i("BART completed!")
-//            return
-//        }
+    fun inflateBalloon(
+        onBalloonPopped:() -> Unit = {},
+        onTestCompleted:() -> Unit = {}
+    ) {
         val canInflate =
             currentState.currentBalloon.maxInflations > currentState.currentInflationCount
 
@@ -51,7 +50,7 @@ class BartViewModel: ViewModel() {
                 currentReward = 1,
                 balloonPopped = true
             )
-            toNextBalloon()
+            toNextBalloon(onTestCompleted)
         }
     }
 
@@ -62,34 +61,27 @@ class BartViewModel: ViewModel() {
         Timber.i("balloonPopped: ${_uiState.value.balloonPopped}")
     }
 
-    fun collectBalloonReward() {
-//        val isListEmpty: Boolean = balloonList.isEmpty()
-//        if (isListEmpty) {
-//            Timber.i("BART completed!")
-//            return
-//        }
+    fun collectBalloonReward(onTestCompleted: () -> Unit) {
         _uiState.value = currentState.copy(
             totalEarnings = currentState.totalEarnings + currentState.currentReward,
             currentReward = 1,
             currentInflationCount = 0
         )
         Timber.i("Balloon Number ${currentState.currentBalloon.listPosition} collected!")
-        toNextBalloon()
+        toNextBalloon(onTestCompleted)
     }
 
-    private fun toNextBalloon() {
-        val isLastBalloon: Boolean = currentState.balloonList.size == 0
-
-        if (isLastBalloon) {
-            /*TODO*/
-            // have something to show test is complete
-            // disable buttons or go to completed screen?
-            Timber.i("BART completed!")
-        } else {
+    private fun toNextBalloon(onTestCompleted: () -> Unit = {}) {
+        if (balloonList.isEmpty()) {
+            onTestCompleted()
+        }
+        try {
             _uiState.value = currentState.copy(
                 balloonList = balloonList,
                 currentBalloon = balloonList.pop()
             )
+        } catch (e:NoSuchElementException) {
+            Timber.i("Test completed or something")
         }
     }
 }

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/Balloon.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/Balloon.kt
@@ -1,4 +1,4 @@
-package com.example.dancognitionapp.bart.model
+package com.example.dancognitionapp.bart.data
 
 data class Balloon(
     val listPosition: Int,

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BalloonGenerator.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BalloonGenerator.kt
@@ -1,0 +1,23 @@
+package com.example.dancognitionapp.bart.data
+
+import com.example.dancognitionapp.bart.model.Balloon
+import java.util.LinkedList
+import kotlin.random.Random
+
+const val MIN_INFLATIONS: Int = 1
+const val MAX_INFLATIONS: Int = 20
+const val NUMBER_OF_BALLOONS: Int = 20
+
+class BalloonGenerator {
+    fun getBalloonLinkedList(): LinkedList<Balloon> {
+
+        val balloonLinkedList = LinkedList<Balloon>()
+
+        for (balloonNumber in 1..NUMBER_OF_BALLOONS) {
+            val maxInflation = Random.nextInt(MIN_INFLATIONS, MAX_INFLATIONS)
+            balloonLinkedList.add(Balloon(balloonNumber, maxInflation))
+        }
+
+        return balloonLinkedList
+    }
+}

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BalloonGenerator.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BalloonGenerator.kt
@@ -1,6 +1,5 @@
 package com.example.dancognitionapp.bart.data
 
-import com.example.dancognitionapp.bart.model.Balloon
 import java.util.LinkedList
 import kotlin.random.Random
 

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BalloonGenerator.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BalloonGenerator.kt
@@ -3,12 +3,18 @@ package com.example.dancognitionapp.bart.data
 import java.util.LinkedList
 import kotlin.random.Random
 
-const val MIN_INFLATIONS: Int = 1
-const val MAX_INFLATIONS: Int = 20
-const val NUMBER_OF_BALLOONS: Int = 20
+private const val MIN_INFLATIONS: Int = 1
+private const val MAX_INFLATIONS: Int = 20
+private const val NUMBER_OF_BALLOONS: Int = 20
 
 class BalloonGenerator {
-    fun getBalloonLinkedList(): LinkedList<Balloon> {
+
+    var balloons = LinkedList<Balloon>()
+    init {
+        balloons = getBalloonLinkedList()
+    }
+
+    private fun getBalloonLinkedList(): LinkedList<Balloon> {
 
         val balloonLinkedList = LinkedList<Balloon>()
 

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BalloonGenerator.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BalloonGenerator.kt
@@ -9,20 +9,15 @@ private const val NUMBER_OF_BALLOONS: Int = 20
 
 class BalloonGenerator {
 
-    var balloons = LinkedList<Balloon>()
+    val balloons = LinkedList<Balloon>()
     init {
-        balloons = getBalloonLinkedList()
+        generateBalloons()
     }
 
-    private fun getBalloonLinkedList(): LinkedList<Balloon> {
-
-        val balloonLinkedList = LinkedList<Balloon>()
-
+    private fun generateBalloons() {
         for (balloonNumber in 1..NUMBER_OF_BALLOONS) {
             val maxInflation = Random.nextInt(MIN_INFLATIONS, MAX_INFLATIONS)
-            balloonLinkedList.add(Balloon(balloonNumber, maxInflation))
+            balloons.add(Balloon(balloonNumber, maxInflation))
         }
-
-        return balloonLinkedList
     }
 }

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
@@ -5,8 +5,8 @@ import java.util.LinkedList
 data class BartUiState(
     val balloonList: LinkedList<Balloon>,
     val currentBalloon: Balloon = balloonList.first,
-    var currentInflationCount: Int = 0,
-    var currentReward: Int = 1,
-    var totalEarnings: Int = 0,
-    var balloonPopped: Boolean = false
+    val currentInflationCount: Int = 0,
+    val currentReward: Int = 1,
+    val totalEarnings: Int = 0,
+    val balloonPopped: Boolean = false
 )

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
@@ -1,0 +1,13 @@
+package com.example.dancognitionapp.bart.data
+
+import com.example.dancognitionapp.bart.model.Balloon
+import java.util.LinkedList
+
+data class BartUiState(
+    val balloonList: LinkedList<Balloon>,
+    val currentBalloon: Balloon = Balloon(1, 1),
+    var balloonInflations: Int = 0,
+    var balloonReward: Int = 1,
+    var totalEarnings: Int = 0,
+    var balloonPopped: Boolean = false
+)

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
@@ -4,9 +4,9 @@ import java.util.LinkedList
 
 data class BartUiState(
     val balloonList: LinkedList<Balloon>,
-    val currentBalloon: Balloon = Balloon(1, 1),
-    var balloonInflations: Int = 0,
-    var balloonReward: Int = 1,
+    val currentBalloon: Balloon = balloonList.first,
+    var currentInflationCount: Int = 0,
+    var currentReward: Int = 1,
     var totalEarnings: Int = 0,
     var balloonPopped: Boolean = false
 )

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
@@ -4,7 +4,7 @@ import java.util.LinkedList
 
 data class BartUiState(
     val balloonList: LinkedList<Balloon>,
-    val currentBalloon: Balloon = balloonList.first,
+    val currentBalloon: Balloon = balloonList.pop(),
     val currentInflationCount: Int = 0,
     val currentReward: Int = 1,
     val totalEarnings: Int = 0,

--- a/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/data/BartUiState.kt
@@ -1,6 +1,5 @@
 package com.example.dancognitionapp.bart.data
 
-import com.example.dancognitionapp.bart.model.Balloon
 import java.util.LinkedList
 
 data class BartUiState(

--- a/app/src/main/java/com/example/dancognitionapp/bart/model/Balloon.kt
+++ b/app/src/main/java/com/example/dancognitionapp/bart/model/Balloon.kt
@@ -1,0 +1,6 @@
+package com.example.dancognitionapp.bart.model
+
+data class Balloon(
+    val listPosition: Int,
+    val maxInflations: Int
+)


### PR DESCRIPTION
This update adds a BartViewModel and a BartUiState to allow for the propagation of state from the UiState to the BartTestScreen. balloonReward and totalEarnings (required for BartTestScreen) were abstracted to the BartUiState class. balloonRadius and initialBalloonRadius could not be abstracted because they depend on the BalloonCanvas Box size. balloonPopped was therefore added to the BartUiState class.