### PR TITLE
Create ParticipantManagerScreen and Modify/Add Participant Screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
             android:theme="@style/Theme.DanCognitionApp"/>
         <activity
             android:name=".participants.ParticipantsActivity"
-            android:theme="@style/Theme.DanCognitionApp"/>
+            android:theme="@style/Theme.DanCognitionApp"
+            android:screenOrientation="portrait"/>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,9 @@
         <activity
             android:name=".assessment.AssessmentActivity"
             android:theme="@style/Theme.DanCognitionApp"/>
+        <activity
+            android:name=".participants.ParticipantsActivity"
+            android:theme="@style/Theme.DanCognitionApp"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/dancognitionapp/MainActivity.kt
+++ b/app/src/main/java/com/example/dancognitionapp/MainActivity.kt
@@ -11,6 +11,8 @@ import com.example.dancognitionapp.assessment.AssessmentActivity
 import com.example.dancognitionapp.ui.landing.LandingDestination
 import com.example.dancognitionapp.ui.theme.DanCognitionAppTheme
 import com.example.dancognitionapp.ui.landing.LandingPageScreen
+import com.example.dancognitionapp.participants.ParticipantsActivity
+import android.content.Intent
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,7 +31,7 @@ class MainActivity : ComponentActivity() {
                             LandingDestination.Practice ->
                                 startActivity(AssessmentActivity.newIntent(this, true))
                             LandingDestination.AddParticipants -> {
-                                //TODO - start participants activity
+                                startActivity(Intent(this, ParticipantsActivity::class.java))
                             }
                         }
                     }

--- a/app/src/main/java/com/example/dancognitionapp/participants/AddModifyParticipantsFragment.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/AddModifyParticipantsFragment.kt
@@ -6,25 +6,26 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
 import com.example.dancognitionapp.R
+import com.example.dancognitionapp.participants.data.Participant
 import com.example.dancognitionapp.ui.theme.DanCognitionAppTheme
+import timber.log.Timber
 
-class ParticipantsViewFragment: Fragment() {
+class AddModifyParticipantsFragment: Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.fragment_compose_host, container, false)
+        val participant = arguments?.getParcelable<Participant?>("selectedParticipant")
         view.findViewById<ComposeView>(R.id.compose_root).setContent {
-            DanCognitionAppTheme() {
-                ParticipantManagerScreen() { participant ->
-                    val bundle = Bundle().apply {
-                        putParcelable("selectedParticipant", participant)
-                    }
-                    findNavController().navigate(R.id.participants_add_modify, bundle)
-                }
+            Timber.i("$participant")
+            DanCognitionAppTheme {
+                AddModifyParticipantsScreen(
+                    isModify = participant != null,
+                    participant = participant
+                )
             }
         }
         return view

--- a/app/src/main/java/com/example/dancognitionapp/participants/AddModifyParticipantsScreen.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/AddModifyParticipantsScreen.kt
@@ -1,0 +1,24 @@
+package com.example.dancognitionapp.participants
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.example.dancognitionapp.participants.data.Participant
+
+@Composable
+fun AddModifyParticipantsScreen(
+    participant: Participant? = null,
+    modifier: Modifier = Modifier,
+    isModify: Boolean = false
+) {
+    if (isModify) {
+        Text(text = participant?.name ?: "Error")
+    } else {
+        Text(text = "Add participant")
+    }
+}
+
+@Composable
+fun AddModifyParticipantsContent() {
+
+}

--- a/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsActivity.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsActivity.kt
@@ -1,0 +1,13 @@
+package com.example.dancognitionapp.participants
+
+import android.os.Bundle
+import androidx.fragment.app.FragmentActivity
+import com.example.dancognitionapp.R
+
+class ParticipantsActivity: FragmentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_participants)
+    }
+}

--- a/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsManagerScreen.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsManagerScreen.kt
@@ -16,9 +16,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LargeFloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -29,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -53,7 +55,7 @@ fun ParticipantManagerScreen(
             DanCognitionTopAppBar(headerResId = R.string.landing_participant_manager)
         },
         floatingActionButton = {
-            FloatingActionButton(
+            LargeFloatingActionButton(
                 onClick = {
                     if (selectedParticipantId != null) {
                         onClickParticipant(selectedParticipantId)
@@ -61,8 +63,7 @@ fun ParticipantManagerScreen(
                         onAdd()
                     }
                 },
-                containerColor = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier.size(76.dp)
+                containerColor = MaterialTheme.colorScheme.secondary
             ) {
                 if (selectedParticipantId != null) {
                     Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
@@ -107,26 +108,32 @@ fun ParticipantCard(
 ) {
     val color by animateColorAsState(
         targetValue = if (isSelected) MaterialTheme.colorScheme.tertiaryContainer
-        else MaterialTheme.colorScheme.primaryContainer
+            else MaterialTheme.colorScheme.primaryContainer
     )
-    Card(modifier = modifier.height(82.dp)) {
-        Column(modifier = Modifier
-            .background(color = color)
-            .fillMaxSize()
+    Card(
+        colors = CardDefaults.cardColors(containerColor = color),
+        modifier = modifier
+            .height(82.dp)
             .clickable { onClick(participant.id) }
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
+            ParticipantIcon()
+            Text(
+                text = participant.name,
+                style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(8.dp)
-            ) {
-                ParticipantIcon()
-                ParticipantInformation(participant.name)
-            }
+                    .padding(8.dp),
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }
 }
+
 
 @Composable
 fun ParticipantIcon(modifier: Modifier = Modifier) {
@@ -138,22 +145,6 @@ fun ParticipantIcon(modifier: Modifier = Modifier) {
             .padding(8.dp)
     )
 }
-
-@Composable
-fun ParticipantInformation(
-    participantName: String,
-    modifier: Modifier = Modifier
-) {
-    Text(
-        text = participantName,
-        style = MaterialTheme.typography.headlineMedium,
-        modifier = Modifier
-            .padding(8.dp),
-        overflow = TextOverflow.Ellipsis
-    )
-}
-
-
 
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsManagerScreen.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsManagerScreen.kt
@@ -1,0 +1,173 @@
+package com.example.dancognitionapp.participants
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.rounded.AccountCircle
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.dancognitionapp.R
+import com.example.dancognitionapp.participants.data.Participant
+import com.example.dancognitionapp.participants.data.participants
+import com.example.dancognitionapp.ui.landing.DanCognitionTopAppBar
+import com.example.dancognitionapp.ui.theme.DanCognitionAppTheme
+import timber.log.Timber
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ParticipantManagerScreen(
+    modifier: Modifier = Modifier,
+    onClickParticipant: (Int?) -> Unit = {},
+    onAdd: () -> Unit = {}
+) {
+    var selectedParticipantId: Int? by remember { mutableStateOf(null) }
+    Scaffold(
+        topBar = {
+            DanCognitionTopAppBar(headerResId = R.string.landing_participant_manager)
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {
+                    if (selectedParticipantId != null) {
+                        onClickParticipant(selectedParticipantId)
+                    } else {
+                        onAdd()
+                    }
+                },
+                containerColor = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.size(76.dp)
+            ) {
+                if (selectedParticipantId != null) {
+                    Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+                } else {
+                    Text(
+                        text = "+",
+                        style = MaterialTheme.typography.displaySmall,
+                    )
+                }
+            }
+        }
+    ) { it ->
+        LazyColumn(contentPadding = it) {
+            items(participants) {participant ->
+                val isSelected = selectedParticipantId == participant.id
+                ParticipantCard(
+                    participant = participant,
+                    modifier = Modifier.padding(8.dp),
+                    isSelected = isSelected
+                ) { participantId ->
+                    if (isSelected) {
+                        /**Allow for deselection*/
+                        Timber.i("Participant $participant de-selected")
+                        selectedParticipantId = null
+                    } else {
+                        selectedParticipantId = participantId
+                        onClickParticipant(participantId)
+                        Timber.i("Participant $participant selected")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ParticipantCard(
+    participant: Participant,
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+    onClick: (Int?) -> Unit = {}
+) {
+    val color by animateColorAsState(
+        targetValue = if (isSelected) MaterialTheme.colorScheme.tertiaryContainer
+        else MaterialTheme.colorScheme.primaryContainer
+    )
+    Card(modifier = modifier.height(82.dp)) {
+        Column(modifier = Modifier
+            .background(color = color)
+            .fillMaxSize()
+            .clickable { onClick(participant.id) }
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            ) {
+                ParticipantIcon()
+                ParticipantInformation(participant.name)
+            }
+        }
+    }
+}
+
+@Composable
+fun ParticipantIcon(modifier: Modifier = Modifier) {
+    Icon(
+        imageVector = Icons.Rounded.AccountCircle,
+        contentDescription = null,
+        modifier = Modifier
+            .size(72.dp)
+            .padding(8.dp)
+    )
+}
+
+@Composable
+fun ParticipantInformation(
+    participantName: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = participantName,
+        style = MaterialTheme.typography.headlineMedium,
+        modifier = Modifier
+            .padding(8.dp),
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+
+
+
+@Preview(showBackground = true)
+@Composable
+fun ParticipantManagerScreenPreview() {
+    DanCognitionAppTheme {
+        ParticipantManagerScreen()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ParticipantCardPreview() {
+    DanCognitionAppTheme {
+        ParticipantCard(participants.first())
+    }
+}

--- a/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsManagerScreen.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsManagerScreen.kt
@@ -1,11 +1,8 @@
 package com.example.dancognitionapp.participants
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -30,7 +27,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -46,10 +42,9 @@ import timber.log.Timber
 @Composable
 fun ParticipantManagerScreen(
     modifier: Modifier = Modifier,
-    onClickParticipant: (Int?) -> Unit = {},
-    onAdd: () -> Unit = {}
+    onFabClick: (Participant?) -> Unit = {}
 ) {
-    var selectedParticipantId: Int? by remember { mutableStateOf(null) }
+    var selectedParticipant: Participant? by remember { mutableStateOf(null) }
     Scaffold(
         topBar = {
             DanCognitionTopAppBar(headerResId = R.string.landing_participant_manager)
@@ -57,15 +52,11 @@ fun ParticipantManagerScreen(
         floatingActionButton = {
             LargeFloatingActionButton(
                 onClick = {
-                    if (selectedParticipantId != null) {
-                        onClickParticipant(selectedParticipantId)
-                    } else {
-                        onAdd()
-                    }
+                    onFabClick(selectedParticipant)
                 },
                 containerColor = MaterialTheme.colorScheme.secondary
             ) {
-                if (selectedParticipantId != null) {
+                if (selectedParticipant != null) {
                     Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
                 } else {
                     Text(
@@ -78,19 +69,18 @@ fun ParticipantManagerScreen(
     ) { it ->
         LazyColumn(contentPadding = it) {
             items(participants) {participant ->
-                val isSelected = selectedParticipantId == participant.id
+                val isSelected = selectedParticipant == participant
                 ParticipantCard(
                     participant = participant,
                     modifier = Modifier.padding(8.dp),
                     isSelected = isSelected
-                ) { participantId ->
+                ) {
                     if (isSelected) {
                         /**Allow for deselection*/
                         Timber.i("Participant $participant de-selected")
-                        selectedParticipantId = null
+                        selectedParticipant = null
                     } else {
-                        selectedParticipantId = participantId
-                        onClickParticipant(participantId)
+                        selectedParticipant = participant
                         Timber.i("Participant $participant selected")
                     }
                 }
@@ -104,7 +94,7 @@ fun ParticipantCard(
     participant: Participant,
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
-    onClick: (Int?) -> Unit = {}
+    onClick: (Participant) -> Unit = {}
 ) {
     val color by animateColorAsState(
         targetValue = if (isSelected) MaterialTheme.colorScheme.tertiaryContainer
@@ -114,7 +104,7 @@ fun ParticipantCard(
         colors = CardDefaults.cardColors(containerColor = color),
         modifier = modifier
             .height(82.dp)
-            .clickable { onClick(participant.id) }
+            .clickable { onClick(participant) }
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsViewFragment.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsViewFragment.kt
@@ -1,0 +1,25 @@
+package com.example.dancognitionapp.participants
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material3.Text
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import com.example.dancognitionapp.R
+
+class ParticipantsViewFragment: Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_compose_host, container, false)
+        view.findViewById<ComposeView>(R.id.compose_root).setContent {
+            Text(text = "Put Participants Screen Here")
+        }
+        return view
+    }
+
+}

--- a/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsViewFragment.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/ParticipantsViewFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import com.example.dancognitionapp.R
+import com.example.dancognitionapp.ui.theme.DanCognitionAppTheme
 
 class ParticipantsViewFragment: Fragment() {
     override fun onCreateView(
@@ -17,7 +18,9 @@ class ParticipantsViewFragment: Fragment() {
     ): View? {
         val view = inflater.inflate(R.layout.fragment_compose_host, container, false)
         view.findViewById<ComposeView>(R.id.compose_root).setContent {
-            Text(text = "Put Participants Screen Here")
+            DanCognitionAppTheme() {
+                ParticipantManagerScreen()
+            }
         }
         return view
     }

--- a/app/src/main/java/com/example/dancognitionapp/participants/data/Participant.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/data/Participant.kt
@@ -1,0 +1,20 @@
+package com.example.dancognitionapp.participants.data
+
+import androidx.annotation.StringRes
+
+data class Participant(
+    val id: Int,
+    val name: String
+)
+
+val participants = listOf<Participant>(
+    Participant(1, "Alex Balan"),
+    Participant(2, "Santa Claus"),
+    Participant(3, "Grant Dong"),
+    Participant(4, "Frauke Tillmans"),
+    Participant(5, "King Kong"),
+    Participant(6, "Rhiannon Brenner"),
+    Participant(7, "Ana Rumpl"),
+    Participant(8, "John Doe"),
+    Participant(9, "Jacques Cousteau")
+)

--- a/app/src/main/java/com/example/dancognitionapp/participants/data/Participant.kt
+++ b/app/src/main/java/com/example/dancognitionapp/participants/data/Participant.kt
@@ -1,11 +1,36 @@
 package com.example.dancognitionapp.participants.data
 
-import androidx.annotation.StringRes
+import android.os.Parcel
+import android.os.Parcelable
 
 data class Participant(
     val id: Int,
     val name: String
-)
+)  : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readInt(),
+        parcel.readString() ?: ""
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(id)
+        parcel.writeString(name)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<Participant> {
+        override fun createFromParcel(parcel: Parcel): Participant {
+            return Participant(parcel)
+        }
+
+        override fun newArray(size: Int): Array<Participant?> {
+            return arrayOfNulls(size)
+        }
+    }
+}
 
 val participants = listOf<Participant>(
     Participant(1, "Alex Balan"),

--- a/app/src/main/res/layout/activity_participants.xml
+++ b/app/src/main/res/layout/activity_participants.xml
@@ -15,6 +15,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
 
         app:defaultNavHost="true"
-        app:navGraph="@navigation/assessment_nav_graph" />
+        app:navGraph="@navigation/participants_nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/assessment_nav_graph.xml
+++ b/app/src/main/res/navigation/assessment_nav_graph.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/nav_graph"
+    android:id="@+id/assessment_nav_graph"
     app:startDestination="@id/selection_dest">
     <fragment
         android:id="@+id/bart_dest"

--- a/app/src/main/res/navigation/participants_nav_graph.xml
+++ b/app/src/main/res/navigation/participants_nav_graph.xml
@@ -6,5 +6,7 @@
     <fragment
         android:id="@+id/participants_view_dest"
         android:name="com.example.dancognitionapp.participants.ParticipantsViewFragment"/>
-
+    <fragment
+        android:id="@+id/participants_add_modify"
+        android:name="com.example.dancognitionapp.participants.AddModifyParticipantsFragment"/>
 </navigation>

--- a/app/src/main/res/navigation/participants_nav_graph.xml
+++ b/app/src/main/res/navigation/participants_nav_graph.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/participants_nav_graph"
+    app:startDestination="@id/participants_view_dest">
+    <fragment
+        android:id="@+id/participants_view_dest"
+        android:name="com.example.dancognitionapp.participants.ParticipantsViewFragment"/>
+
+</navigation>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.DanCognitionApp" parent="Theme.AppCompat.Light.NoActionBar" />
+    <style name="Theme.DanCognitionApp" parent="android:Theme.Material.Light.NoActionBar" />
 </resources>


### PR DESCRIPTION
This update adds some of the logic and UI for the participant manager section of the app.

Some of the key features:
- Added Participants Activity
- Added Navigation from Landing to ParticipantsActivity
-  Mock participants and data class in Participant.kt
- Participant manager screen displays a list of participants with clickable cards and changing (modify/add) FAB
- Clicking on a Participant highlights that card and allows you to edit its contents (by clicking FAB) 

I'm sure the Parcel is not the most efficient way of sending the participant that is selected but it was my best shot lol.